### PR TITLE
NameError fix in _checkDigitsTD1

### DIFF
--- a/pypassport/doc9303/mrz.py
+++ b/pypassport/doc9303/mrz.py
@@ -83,11 +83,11 @@ class MRZ(object):
         if mrz1[14] == "<":
             #Document number is bigger than 9 caracters
             tmp = mrz1[15:30].strip("<")
-            self._docNumber = mrz[5:14] + tmp[:-1]
+            self._docNumber = mrz1[5:14] + tmp[:-1]
             self._docNumberCD = tmp[-1]
         else:
-            self._docNumber = mrz[5:14]
-            self._docNumberCD = mrz[14]
+            self._docNumber = mrz1[5:14]
+            self._docNumberCD = mrz1[14]
             
         self._dateOfBirth = mrz2[0:6]
         self._dateOfBirthCD = mrz2[6]


### PR DESCRIPTION
There are two parts of mrz string passes as mrz1 and mrz2 parameters for a 60 character version mrz check,
but there are some code expected mrz parametr, and it causes: NameError: name 'mrz' is not defined.
44 character version mrz check was not affected by this issue.